### PR TITLE
feat: Add Printful catalog data

### DIFF
--- a/gatsby-source-printful/gatsby-node.js
+++ b/gatsby-source-printful/gatsby-node.js
@@ -157,6 +157,7 @@ exports.sourceNodes = async (
       slug: parseNameForSlug(variant.name),
       retail_price: parsePriceString(variant.retail_price),
       parentProduct___NODE: sync_product_id,
+      catalogVariant___NODE: variant.variant_id.toString(),
       variantImage___NODE: variantImageNode,
       internal: {
         type: `PrintfulVariant`,

--- a/gatsby-source-printful/gatsby-node.js
+++ b/gatsby-source-printful/gatsby-node.js
@@ -69,6 +69,12 @@ exports.sourceNodes = async (
     []
   )
 
+  const catalogVariants = await Promise.all(
+    uniqueCatalogVariantIds.map(
+      async (id) => await printful.get(`products/variant/${id}`)
+    )
+  )
+
   const { result: countries } = await printful.get(`countries`)
 
   const processCountry = async (country) => {

--- a/gatsby-source-printful/gatsby-node.js
+++ b/gatsby-source-printful/gatsby-node.js
@@ -57,6 +57,18 @@ exports.sourceNodes = async (
   const products = await Promise.all(
     result.map(async ({ id }) => await printful.get(`sync/products/${id}`))
   )
+
+  const catalogVariantIds = products
+    .map(({ result: { sync_variants: variants } }) =>
+      variants.map(({ variant_id }) => variant_id)
+    )
+    .flat()
+
+  const uniqueCatalogVariantIds = catalogVariantIds.reduce(
+    (unique, item) => (unique.includes(item) ? unique : [...unique, item]),
+    []
+  )
+
   const { result: countries } = await printful.get(`countries`)
 
   const processCountry = async (country) => {


### PR DESCRIPTION
This PR builds `PrintfulCatalogVariant` and `PrintfulCatalogProduct` nodes for Printful catalog products related to synced variants and products.

## Todo

- [x] Build `PrintfulCatalogProduct` nodes
- [x] Add relations to `PrintfulVariant`, `PrintfulProduct` nodes