### PR TITLE
chore: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "automerge": true,
   "extends": ["config:base", "schedule:weekly"],
+  "ignorePresets": [":semanticPrefixFixDepsChoreOthers"],
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
Ignore the `semanticPrefixFixDepsChoreOther` preset to ensure `chore` prefix is used for PRs/commits