### PR TITLE
feat: check options validity during onPreBootstrap

### DIFF
--- a/gatsby-source-printful/gatsby-node.js
+++ b/gatsby-source-printful/gatsby-node.js
@@ -2,18 +2,11 @@ const { createRemoteFileNode } = require('gatsby-source-filesystem')
 
 const PrintfulClient = require('./lib/printful')
 const { parseNameForSlug, parsePriceString } = require('./lib/utils')
+const withDefaultOptions = require('./plugin-options')
 
-exports.sourceNodes = async (
-  {
-    actions: { createNode },
-    cache,
-    createContentDigest,
-    createNodeId,
-    store,
-    reporter
-  },
-  { apiKey, paginationLimit = 20 }
-) => {
+exports.onPreBootstrap = ({ reporter }, pluginOptions) => {
+  const { apiKey, paginationLimit } = withDefaultOptions(pluginOptions)
+
   if (!apiKey)
     return reporter.panic(
       'gatsby-source-printful: You must provide your Printful API key'
@@ -27,6 +20,13 @@ exports.sourceNodes = async (
     return reporter.panic(
       'gatsby-source-printful: `paginationLimit` must be an integer, no greater than 100'
     )
+}
+
+exports.sourceNodes = async (
+  { actions: { createNode }, cache, createContentDigest, createNodeId, store },
+  pluginOptions
+) => {
+  const { apiKey, paginationLimit } = withDefaultOptions(pluginOptions)
 
   const printful = new PrintfulClient({
     apiKey

--- a/gatsby-source-printful/plugin-options.js
+++ b/gatsby-source-printful/plugin-options.js
@@ -1,0 +1,6 @@
+const defaultOptions = (options) => ({
+  paginationLimit: 20,
+  ...options
+})
+
+module.exports = defaultOptions


### PR DESCRIPTION
As it says in the title, checking the plugin options during `onPreBootstrap` is faster if you have more than just `gatsby-source-printful` installed.

Not sure if it's a chore/fix or feat. I'll let you rename accordingly for semantic release 😅 